### PR TITLE
Fixes incorrect parsing of phone numbers

### DIFF
--- a/lib/Metaname.php
+++ b/lib/Metaname.php
@@ -136,7 +136,7 @@ EOF;
     # Try to detect the area code
     $fullphonenumber = trim( $params[$prefix.'fullphonenumber'] );
     $matches = array();
-    if ( preg_match('/\+(\d+)\.(.+)', $fullphonenumber, $matches) )
+    if ( preg_match('/\+(\d+)\.(.+)/', $fullphonenumber, $matches) )
     {
       $country_code =    $matches[1];
       $national_number = $matches[2];


### PR DESCRIPTION
Current code results in error:

PHP Warning:  preg_match(): No ending delimiter '/' found in [file] on line 3

New code now returns true if regex matches
